### PR TITLE
Fixed docstring typo in ResponseLater

### DIFF
--- a/channels/response.py
+++ b/channels/response.py
@@ -31,7 +31,7 @@ def decode_response(value):
 
 class ResponseLater(Exception):
     """
-    Class that represents a response which will be sent doown the response
+    Class that represents a response which will be sent down the response
     channel later. Used to move a django view-based segment onto the next
     task, as otherwise we'd need to write some kind of fake response.
     """


### PR DESCRIPTION
There's a small typo: "doown"